### PR TITLE
Improve network graph layout

### DIFF
--- a/apps/frontend/src/components/visual-navigator/graph/graph-display.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/graph-display.ts
@@ -16,9 +16,10 @@ export function getVertexTransform(vertex: ViewVertex): string {
 }
 
 export function getVertexRadius(vertex: ViewVertex): number {
-  if (vertex.selected) return 13;
-  if (vertex.isPartOfTransitiveQuorumSet) return 10;
-  return 8.5;
+  if (vertex.selected) return 14.5;
+  if (vertex.isPartOfTransitiveQuorumSet) return 11.5;
+  if (vertex.isPerimeter) return 8;
+  return 9.5;
 }
 
 export function getVertexStyle(vertex: ViewVertex): Record<string, string> {
@@ -92,7 +93,7 @@ function getVertexTextRectWidth(
   vertex: ViewVertex,
   truncate: (value: string, length: number) => string,
 ): number {
-  return Math.max(36, truncate(vertex.label, 12).length * 5.5 + 8);
+  return Math.max(44, truncate(vertex.label, 14).length * 6.2 + 10);
 }
 
 function highlightVertexAsOutgoing(

--- a/apps/frontend/src/components/visual-navigator/graph/graph.scss
+++ b/apps/frontend/src/components/visual-navigator/graph/graph.scss
@@ -5,7 +5,12 @@ svg.graph {
   cursor: grab;
   touch-action: none;
   overscroll-behavior: contain;
+  overflow: hidden;
   background: #fbfdff;
+}
+
+.svg-wrapper {
+  overflow: hidden;
 }
 
 .dimmer.active .dimmer-content {

--- a/apps/frontend/src/components/visual-navigator/graph/graph.scss
+++ b/apps/frontend/src/components/visual-navigator/graph/graph.scss
@@ -15,14 +15,14 @@ svg.graph {
 path.edge {
   stroke: var(--edge-color, $graph-primary);
   stroke-width: 0.7px;
-  stroke-opacity: 0.16;
+  stroke-opacity: 0.12;
   fill-opacity: 0;
 }
 
 path.strongly-connected {
   stroke: var(--edge-color, $graph-primary);
   stroke-width: 1.1px;
-  stroke-opacity: 0.44;
+  stroke-opacity: 0.5;
 }
 
 path.failing {
@@ -88,16 +88,35 @@ circle {
   stroke: $white;
   fill: $gray-100;
   cursor: pointer;
-  stroke-width: 1.75px;
+  stroke-width: 2px;
 }
 
 text {
-  fill: #2f5f7c;
-  font-weight: 400;
+  fill: #244d68;
+  font-weight: 500;
   paint-order: stroke;
   stroke: white;
   stroke-linejoin: round;
-  stroke-width: 1.6px;
+  stroke-width: 1.9px;
+}
+
+.vertex-label {
+  transition: opacity 120ms ease-in-out;
+}
+
+.perimeter-vertex .vertex-label {
+  opacity: 0;
+}
+
+.secondary-vertex .vertex-label {
+  opacity: 0;
+}
+
+.perimeter-vertex:hover .vertex-label,
+.perimeter-vertex:focus .vertex-label,
+.secondary-vertex:hover .vertex-label,
+.secondary-vertex:focus .vertex-label {
+  opacity: 1;
 }
 
 .failing {
@@ -110,7 +129,13 @@ text {
 }
 
 .rect {
-  opacity: 0.8;
+  opacity: 0.9;
+}
+
+.vertex-label-background {
+  fill: white;
+  opacity: 0.92;
+  text-transform: lowercase;
 }
 
 .rect-selected {

--- a/apps/frontend/src/components/visual-navigator/graph/graph.vue
+++ b/apps/frontend/src/components/visual-navigator/graph/graph.vue
@@ -135,6 +135,11 @@
               :key="vertex.key"
               :transform="getVertexTransform(vertex)"
               class="vertex"
+              :class="{
+                'perimeter-vertex': vertex.isPerimeter,
+                'secondary-vertex':
+                  !vertex.isPartOfTransitiveQuorumSet && !vertex.selected,
+              }"
               style="cursor: pointer"
               @click="
                 vertexSelected(vertex);
@@ -148,14 +153,14 @@
               >
                 <title>{{ vertex.label }}</title>
               </circle>
-              <g>
+              <g class="vertex-label">
                 <rect
-                  style="fill: white; opacity: 0.84; text-transform: lowercase"
+                  class="vertex-label-background"
                   :width="getVertexTextRectWidthPx(vertex)"
-                  height="12px"
-                  y="13"
+                  height="15px"
+                  y="14"
                   :x="getVertexTextRectX(vertex)"
-                  rx="2"
+                  rx="3"
                   :class="{
                     'rect-selected': vertex.selected,
                     rect: !vertex.selected,
@@ -164,11 +169,11 @@
                 <text
                   y="5"
                   :class="getVertexTextClass(vertex)"
-                  dy="1.7em"
+                  dy="1.9em"
                   text-anchor="middle"
-                  font-size="9px"
+                  font-size="10.5px"
                 >
-                  {{ truncate(vertex.label, 12) }}
+                  {{ truncate(vertex.label, 14) }}
                   <title>{{ vertex.label }}</title>
                 </text>
               </g>

--- a/apps/frontend/src/components/visual-navigator/graph/use-graph-controller.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/use-graph-controller.ts
@@ -146,6 +146,7 @@ export function useGraphController(options: GraphControllerOptions) {
       if (!vertex) return;
       vertex.x = updatedVertex.x;
       vertex.y = updatedVertex.y;
+      vertex.isPerimeter = updatedVertex.isPerimeter;
     });
 
     edges.forEach((updatedEdge) => {

--- a/apps/frontend/src/components/visual-navigator/graph/view-vertex.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/view-vertex.ts
@@ -11,6 +11,7 @@ export default class ViewVertex {
   isTrustedBySelectedVertex = false;
   selected = false;
   isFailing = false;
+  isPerimeter = false;
   groupKey: string | null = null;
   groupIndex = 0;
   color = getGraphGroupColor(null);

--- a/apps/frontend/src/views/Dashboard.vue
+++ b/apps/frontend/src/views/Dashboard.vue
@@ -49,16 +49,16 @@
         </HaltingAnalysis>
       </div>
     </div>
-    <div class="row h-100">
-      <aside class="col-xs-12 col-sm-5 col-lg-3 col-xl-auto mb-5">
+    <div class="dashboard-shell h-100">
+      <aside class="dashboard-sidebar mb-5">
         <div class="card pt-0 sidebar-card h-100">
           <transition name="fade" mode="out-in">
             <router-view name="sideBar" class="h-100 side-bar" />
           </transition>
         </div>
       </aside>
-      <div id="content" class="col-sm-7 col-lg-9 col-xl">
-        <div class="row">
+      <div id="content" class="dashboard-content">
+        <div class="row navigator-row">
           <div class="col">
             <network-visual-navigator :view="view" />
           </div>
@@ -166,7 +166,49 @@ watch(haltingAnalysisPublicKey, (publicKey) => {
 </script>
 
 <style scoped>
+.dashboard-shell {
+  display: block;
+  position: relative;
+}
+
+.dashboard-sidebar {
+  width: 100%;
+}
+
 @media (min-width: 1279px) {
+  .dashboard-sidebar {
+    left: 0;
+    margin-bottom: 0 !important;
+    position: absolute;
+    top: 0;
+    width: 292px;
+    z-index: 5;
+  }
+
+  .sidebar-card {
+    backdrop-filter: blur(8px);
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: 0 12px 35px rgba(44, 62, 80, 0.12);
+    height: min(88vh, 1040px) !important;
+    max-height: 1040px;
+    overflow: hidden;
+  }
+
+  .dashboard-content {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .navigator-row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .navigator-row > .col {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   .side-bar {
     width: 272px;
   }

--- a/apps/frontend/src/workers/compute-graphv9.worker.ts
+++ b/apps/frontend/src/workers/compute-graphv9.worker.ts
@@ -152,7 +152,7 @@ ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
     simulatedVertices,
     getSimulatedVertexBounds(layoutBounds, perimeterVertices.length),
   );
-  placePerimeterVertices(perimeterVertices, layoutBounds);
+  placePerimeterVertices(perimeterVertices, layoutBounds, width, height);
   hydrateEdgeEndpoints(edges, vertexByKey);
   ctx.postMessage({ type: "end", vertices: vertices, edges: edges });
 });
@@ -246,19 +246,58 @@ function getPerimeterVertices(
 function placePerimeterVertices(
   vertices: GraphNodeDatum[],
   bounds: LayoutBounds,
+  viewportWidth: number,
+  viewportHeight: number,
 ): void {
   if (vertices.length === 0) return;
 
-  const columns = Math.max(8, Math.ceil(Math.sqrt(vertices.length)));
-  const startX = bounds.right + 180;
-  const startY = bounds.top + 48;
-  const columnGap = 48;
-  const rowGap = 38;
+  const center = centerOf(bounds);
+  const baseRadius = farthestViewportCornerDistance(
+    center,
+    viewportWidth,
+    viewportHeight,
+  );
+  const ringGap = 78;
+  const minimumCircleSpacing = 42;
+  let vertexIndex = 0;
+  let ringIndex = 0;
 
-  vertices.forEach((vertex, index) => {
-    vertex.x = startX + (index % columns) * columnGap;
-    vertex.y = startY + Math.floor(index / columns) * rowGap;
-  });
+  while (vertexIndex < vertices.length) {
+    const radius = baseRadius + 96 + ringIndex * ringGap;
+    const ringCapacity = Math.max(
+      16,
+      Math.floor((Math.PI * 2 * radius) / minimumCircleSpacing),
+    );
+    const verticesOnRing = Math.min(
+      vertices.length - vertexIndex,
+      ringCapacity,
+    );
+    const angleOffset =
+      -Math.PI / 2 + (ringIndex % 2) * (Math.PI / verticesOnRing);
+
+    for (let step = 0; step < verticesOnRing; step += 1) {
+      const vertex = vertices[vertexIndex];
+      const angle = angleOffset + (step / verticesOnRing) * Math.PI * 2;
+      vertex.x = center.x + Math.cos(angle) * radius;
+      vertex.y = center.y + Math.sin(angle) * radius;
+      vertexIndex += 1;
+    }
+
+    ringIndex += 1;
+  }
+}
+
+function farthestViewportCornerDistance(
+  center: Point,
+  viewportWidth: number,
+  viewportHeight: number,
+): number {
+  return Math.max(
+    Math.hypot(center.x, center.y),
+    Math.hypot(viewportWidth - center.x, center.y),
+    Math.hypot(center.x, viewportHeight - center.y),
+    Math.hypot(viewportWidth - center.x, viewportHeight - center.y),
+  );
 }
 
 function fitVerticesToBounds(

--- a/apps/frontend/src/workers/compute-graphv9.worker.ts
+++ b/apps/frontend/src/workers/compute-graphv9.worker.ts
@@ -1,5 +1,6 @@
 import {
   forceCenter,
+  forceCollide,
   forceLink,
   forceManyBody,
   forceSimulation,
@@ -35,6 +36,18 @@ type GraphWorkerScope = {
   postMessage: (message: GraphWorkerResponse) => void;
 };
 
+type LayoutBounds = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
+
+type Point = {
+  x: number;
+  y: number;
+};
+
 const ctx = self as GraphWorkerScope;
 
 ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
@@ -42,57 +55,85 @@ ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
   const edges = event.data.edges as GraphLinkDatum[];
   const width = event.data.width;
   const height = event.data.height;
+  const vertexByKey = new Map(vertices.map((vertex) => [vertex.key, vertex]));
+  const layoutBounds = getLayoutBounds(width, height);
+  const graphCenter = centerOf(layoutBounds);
+  const degrees = getVertexDegrees(edges);
+  const perimeterVertices = getPerimeterVertices(vertices, degrees);
+  const perimeterVertexKeys = new Set(
+    perimeterVertices.map((vertex) => vertex.key),
+  );
+  vertices.forEach((vertex) => {
+    vertex.isPerimeter = perimeterVertexKeys.has(vertex.key);
+  });
+  const simulatedVertices = vertices.filter(
+    (vertex) => !perimeterVertexKeys.has(vertex.key),
+  );
+  const simulatedEdges = edges.filter(
+    (edge) =>
+      !perimeterVertexKeys.has(endpointKey(edge.source)) &&
+      !perimeterVertexKeys.has(endpointKey(edge.target)),
+  );
 
   const nrOfTransitiveVertices = Math.max(
-    vertices.filter((vertex) => vertex.isPartOfTransitiveQuorumSet).length,
+    simulatedVertices.filter((vertex) => vertex.isPartOfTransitiveQuorumSet)
+      .length,
     1,
   );
   const nrOfGroups = Math.max(
-    new Set(vertices.map((vertex) => vertex.groupIndex)).size,
+    new Set(simulatedVertices.map((vertex) => vertex.groupIndex)).size,
     1,
   );
-  const groupCenterRadius = Math.min(width, height) * 0.42;
+  const groupCenterRadius =
+    Math.min(widthOf(layoutBounds), heightOf(layoutBounds)) * 0.43;
 
-  const simulation = forceSimulation<GraphNodeDatum>(vertices)
+  const simulation = forceSimulation<GraphNodeDatum>(simulatedVertices)
     .force(
       "charge",
       forceManyBody<GraphNodeDatum>().strength((vertex) => {
-        return vertex.isPartOfTransitiveQuorumSet ? -760 : -430;
+        return vertex.isPartOfTransitiveQuorumSet ? -760 : -420;
       }),
     )
     .force(
       "link",
-      forceLink<GraphNodeDatum, GraphLinkDatum>(edges)
+      forceLink<GraphNodeDatum, GraphLinkDatum>(simulatedEdges)
         .distance((edge) => {
-          return edge.isPartOfTransitiveQuorumSet ? 110 : 175;
+          return edge.isPartOfTransitiveQuorumSet ? 112 : 170;
         })
         .strength((edge: SimulationLinkDatum<GraphNodeDatum>) => {
           const viewEdge = edge as GraphLinkDatum;
           if (viewEdge.isPartOfTransitiveQuorumSet) {
-            return (1 / nrOfTransitiveVertices) * 0.17;
+            return (1 / nrOfTransitiveVertices) * 0.2;
           } else if (viewEdge.isPartOfStronglyConnectedComponent) {
-            return 0.1;
+            return 0.11;
           } else {
-            return 0.004;
+            return 0.006;
           }
         })
         .id((vertex) => vertex.key),
     )
     .force(
+      "collision",
+      forceCollide<GraphNodeDatum>()
+        .radius((vertex) => (vertex.isPartOfTransitiveQuorumSet ? 34 : 22))
+        .strength(0.72)
+        .iterations(2),
+    )
+    .force(
       "x",
       forceX<GraphNodeDatum>(
         (vertex) =>
-          groupCenter(vertex, nrOfGroups, width, height, groupCenterRadius).x,
-      ).strength(0.12),
+          groupCenter(vertex, nrOfGroups, graphCenter, groupCenterRadius).x,
+      ).strength(0.11),
     )
     .force(
       "y",
       forceY<GraphNodeDatum>(
         (vertex) =>
-          groupCenter(vertex, nrOfGroups, width, height, groupCenterRadius).y,
-      ).strength(0.12),
+          groupCenter(vertex, nrOfGroups, graphCenter, groupCenterRadius).y,
+      ).strength(0.11),
     )
-    .force("center", forceCenter(width / 2, height / 2))
+    .force("center", forceCenter(graphCenter.x, graphCenter.y))
     .velocityDecay(0.38)
     .stop();
 
@@ -107,25 +148,173 @@ ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
     //ctx.postMessage({type: 'tick', progress: i / n});
     simulation.tick();
   }
+  fitVerticesToBounds(
+    simulatedVertices,
+    getSimulatedVertexBounds(layoutBounds, perimeterVertices.length),
+  );
+  placePerimeterVertices(perimeterVertices, layoutBounds);
+  hydrateEdgeEndpoints(edges, vertexByKey);
   ctx.postMessage({ type: "end", vertices: vertices, edges: edges });
 });
 
 function groupCenter(
   vertex: GraphNodeDatum,
   nrOfGroups: number,
-  width: number,
-  height = width,
-  radius = Math.min(width, height) * 0.34,
+  center: Point,
+  radius: number,
 ): { x: number; y: number } {
   if (nrOfGroups <= 1) {
-    return { x: width / 2, y: height / 2 };
+    return center;
   }
 
   const angle = (vertex.groupIndex / nrOfGroups) * Math.PI * 2;
   return {
-    x: width / 2 + Math.cos(angle) * radius,
-    y: height / 2 + Math.sin(angle) * radius,
+    x: center.x + Math.cos(angle) * radius,
+    y: center.y + Math.sin(angle) * radius,
   };
+}
+
+function getLayoutBounds(width: number, height: number): LayoutBounds {
+  const overlayMargin = width >= 992 ? Math.min(300, width * 0.24) : 24;
+
+  return {
+    left: overlayMargin + 30,
+    right: Math.max(overlayMargin + 120, width - 36),
+    top: 36,
+    bottom: Math.max(160, height - 42),
+  };
+}
+
+function getSimulatedVertexBounds(
+  bounds: LayoutBounds,
+  perimeterVertexCount: number,
+): LayoutBounds {
+  const perimeterPadding = perimeterVertexCount > 0 ? 34 : 40;
+
+  return {
+    left: bounds.left + 30,
+    right: bounds.right - perimeterPadding,
+    top: bounds.top + 30,
+    bottom: bounds.bottom - Math.max(30, perimeterPadding),
+  };
+}
+
+function centerOf(bounds: LayoutBounds): Point {
+  return {
+    x: bounds.left + widthOf(bounds) / 2,
+    y: bounds.top + heightOf(bounds) / 2,
+  };
+}
+
+function widthOf(bounds: LayoutBounds): number {
+  return bounds.right - bounds.left;
+}
+
+function heightOf(bounds: LayoutBounds): number {
+  return bounds.bottom - bounds.top;
+}
+
+function getVertexDegrees(edges: GraphLinkDatum[]): Map<string, number> {
+  const degrees = new Map<string, number>();
+  edges.forEach((edge) => {
+    incrementDegree(degrees, endpointKey(edge.source));
+    incrementDegree(degrees, endpointKey(edge.target));
+  });
+
+  return degrees;
+}
+
+function incrementDegree(degrees: Map<string, number>, key: string): void {
+  degrees.set(key, (degrees.get(key) ?? 0) + 1);
+}
+
+function getPerimeterVertices(
+  vertices: GraphNodeDatum[],
+  degrees: Map<string, number>,
+): GraphNodeDatum[] {
+  if (vertices.length < 24) return [];
+
+  return vertices
+    .filter(
+      (vertex) =>
+        !vertex.isPartOfTransitiveQuorumSet &&
+        (degrees.get(vertex.key) ?? 0) === 0,
+    )
+    .sort((first, second) => first.label.localeCompare(second.label));
+}
+
+function placePerimeterVertices(
+  vertices: GraphNodeDatum[],
+  bounds: LayoutBounds,
+): void {
+  if (vertices.length === 0) return;
+
+  const columns = Math.max(8, Math.ceil(Math.sqrt(vertices.length)));
+  const startX = bounds.right + 180;
+  const startY = bounds.top + 48;
+  const columnGap = 48;
+  const rowGap = 38;
+
+  vertices.forEach((vertex, index) => {
+    vertex.x = startX + (index % columns) * columnGap;
+    vertex.y = startY + Math.floor(index / columns) * rowGap;
+  });
+}
+
+function fitVerticesToBounds(
+  vertices: GraphNodeDatum[],
+  bounds: LayoutBounds,
+): void {
+  if (vertices.length === 0) return;
+
+  const extent = vertices.reduce(
+    (currentExtent, vertex) => {
+      return {
+        left: Math.min(currentExtent.left, vertex.x ?? 0),
+        right: Math.max(currentExtent.right, vertex.x ?? 0),
+        top: Math.min(currentExtent.top, vertex.y ?? 0),
+        bottom: Math.max(currentExtent.bottom, vertex.y ?? 0),
+      };
+    },
+    {
+      left: Number.POSITIVE_INFINITY,
+      right: Number.NEGATIVE_INFINITY,
+      top: Number.POSITIVE_INFINITY,
+      bottom: Number.NEGATIVE_INFINITY,
+    },
+  );
+
+  const extentWidth = Math.max(extent.right - extent.left, 1);
+  const extentHeight = Math.max(extent.bottom - extent.top, 1);
+  const scale = Math.min(
+    widthOf(bounds) / extentWidth,
+    heightOf(bounds) / extentHeight,
+    1.08,
+  );
+  const targetCenter = centerOf(bounds);
+  const extentCenter = {
+    x: extent.left + extentWidth / 2,
+    y: extent.top + extentHeight / 2,
+  };
+
+  vertices.forEach((vertex) => {
+    vertex.x = targetCenter.x + ((vertex.x ?? 0) - extentCenter.x) * scale;
+    vertex.y = targetCenter.y + ((vertex.y ?? 0) - extentCenter.y) * scale;
+  });
+}
+
+function hydrateEdgeEndpoints(
+  edges: GraphLinkDatum[],
+  vertexByKey: Map<string, GraphNodeDatum>,
+): void {
+  edges.forEach((edge) => {
+    edge.source = vertexByKey.get(endpointKey(edge.source)) ?? edge.source;
+    edge.target = vertexByKey.get(endpointKey(edge.target)) ?? edge.target;
+  });
+}
+
+function endpointKey(endpoint: string | GraphNodeDatum): string {
+  return typeof endpoint === "string" ? endpoint : endpoint.key;
 }
 
 export default ctx;


### PR DESCRIPTION
## Summary

- enlarge and rebalance the network graph surface with the sidebar overlaid on desktop
- improve graph readability with stronger core clustering, larger node marks, quieter secondary labels, and scroll/pinch zoom support
- arrange isolated connectable nodes in concentric off-canvas rings so the initial view stays focused on connected network structure

## Validation

- `pnpm --filter frontend run build`
- Local browser verification of the dashboard graph at 1600px wide viewport
