### PR TITLE
Improve graph labels and add 3D view

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -10,6 +10,7 @@
     "start": "node server-lib/server.js"
   },
   "dependencies": {
+    "3d-force-graph": "1.80.0",
     "@sentry/vue": "^8.34.0",
     "@stellarbeat/stellar-halting-analysis": "1.2.0",
     "@stellarbeat/stellar_analysis_web": "^0.7.0",
@@ -38,6 +39,8 @@
     "portal-vue": "^2.1.7",
     "scp-simulation": "workspace:*",
     "shared": "workspace:*",
+    "three": "0.185.1",
+    "three-spritetext": "1.10.0",
     "vue": "^2.7.16",
     "vue-multiselect": "^2.1.9",
     "vue-router": "^3.6.5"
@@ -56,6 +59,7 @@
     "@types/leaflet": "^1.9.21",
     "@types/leaflet.markercluster": "^1.5.6",
     "@types/node": "^26.0.1",
+    "@types/three": "0.185.0",
     "@vitejs/plugin-vue2": "^2.3.4",
     "ajv-formats": "^2.1.1",
     "jest-localstorage-mock": "^2.4.26",

--- a/apps/frontend/src/components/visual-navigator/graph/graph-3d-camera.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/graph-3d-camera.ts
@@ -1,0 +1,84 @@
+import type { Graph3DNode } from "@/components/visual-navigator/graph/graph-3d-data";
+
+export interface Graph3DCameraVector {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface Graph3DCameraTarget {
+  position: Graph3DCameraVector;
+  lookAt: Graph3DCameraVector;
+}
+
+export function getInitialGraph3DCameraTarget(): Graph3DCameraTarget {
+  return {
+    position: { x: 220, y: 150, z: 360 },
+    lookAt: { x: 0, y: 0, z: 0 },
+  };
+}
+
+export function getGraph3DCameraTarget(
+  nodes: Graph3DNode[],
+): Graph3DCameraTarget | null {
+  const positionedNodes = nodes.filter(
+    (node): node is RequiredPositionNode =>
+      !node.isPerimeter && hasNodePosition(node),
+  );
+  if (positionedNodes.length === 0) return null;
+
+  const bounds = getBounds(positionedNodes);
+  const lookAt = {
+    x: (bounds.minX + bounds.maxX) / 2,
+    y: (bounds.minY + bounds.maxY) / 2,
+    z: (bounds.minZ + bounds.maxZ) / 2,
+  };
+  const span = Math.max(
+    bounds.maxX - bounds.minX,
+    bounds.maxY - bounds.minY,
+    bounds.maxZ - bounds.minZ,
+    1,
+  );
+  const distance = Math.max(150, span * 1.05 + 56);
+
+  return {
+    position: {
+      x: lookAt.x + distance * 0.72,
+      y: lookAt.y + distance * 0.52,
+      z: lookAt.z + distance,
+    },
+    lookAt,
+  };
+}
+
+function getBounds(nodes: RequiredPositionNode[]) {
+  return nodes.reduce(
+    (bounds, node) => ({
+      minX: Math.min(bounds.minX, node.x),
+      maxX: Math.max(bounds.maxX, node.x),
+      minY: Math.min(bounds.minY, node.y),
+      maxY: Math.max(bounds.maxY, node.y),
+      minZ: Math.min(bounds.minZ, node.z),
+      maxZ: Math.max(bounds.maxZ, node.z),
+    }),
+    {
+      minX: Number.POSITIVE_INFINITY,
+      maxX: Number.NEGATIVE_INFINITY,
+      minY: Number.POSITIVE_INFINITY,
+      maxY: Number.NEGATIVE_INFINITY,
+      minZ: Number.POSITIVE_INFINITY,
+      maxZ: Number.NEGATIVE_INFINITY,
+    },
+  );
+}
+
+type RequiredPositionNode = Graph3DNode &
+  Required<Pick<Graph3DNode, "x" | "y" | "z">>;
+
+function hasNodePosition(node: Graph3DNode): node is RequiredPositionNode {
+  return (
+    Number.isFinite(node.x) &&
+    Number.isFinite(node.y) &&
+    Number.isFinite(node.z)
+  );
+}

--- a/apps/frontend/src/components/visual-navigator/graph/graph-3d-data.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/graph-3d-data.ts
@@ -1,0 +1,162 @@
+import type { LinkObject, NodeObject } from "3d-force-graph";
+import ViewEdge from "@/components/visual-navigator/graph/view-edge";
+import ViewGraph from "@/components/visual-navigator/graph/view-graph";
+import ViewVertex from "@/components/visual-navigator/graph/view-vertex";
+
+export interface Graph3DNode extends NodeObject {
+  id: string;
+  key: string;
+  label: string;
+  color: string;
+  val: number;
+  selected: boolean;
+  isFailing: boolean;
+  isPerimeter: boolean;
+  isPartOfTransitiveQuorumSet: boolean;
+  groupIndex: number;
+}
+
+export interface Graph3DLink extends LinkObject<Graph3DNode> {
+  source: string | Graph3DNode;
+  target: string | Graph3DNode;
+  color: string;
+  highlighted: boolean;
+  isFailing: boolean;
+  isPartOfStronglyConnectedComponent: boolean;
+  isPartOfTransitiveQuorumSet: boolean;
+}
+
+export interface Graph3DData {
+  nodes: Graph3DNode[];
+  links: Graph3DLink[];
+}
+
+interface Graph3DDataOptions {
+  showFailingEdges: boolean;
+  transitiveQuorumSetOnly: boolean;
+}
+
+export function buildGraph3DData(
+  viewGraph: ViewGraph,
+  options: Graph3DDataOptions,
+): Graph3DData {
+  const visibleVertices = Array.from(viewGraph.viewVertices.values()).filter(
+    (vertex) =>
+      vertex.isPartOfTransitiveQuorumSet || !options.transitiveQuorumSetOnly,
+  );
+  const visibleKeys = new Set(visibleVertices.map((vertex) => vertex.key));
+  const layout = getInitialLayout(visibleVertices);
+
+  return {
+    nodes: visibleVertices.map((vertex) => ({
+      id: vertex.key,
+      key: vertex.key,
+      label: vertex.label,
+      color: vertex.color,
+      val: getNodeValue(vertex.isPartOfTransitiveQuorumSet, vertex.selected),
+      groupIndex: vertex.groupIndex,
+      selected: vertex.selected,
+      isFailing: vertex.isFailing,
+      isPerimeter: vertex.isPerimeter,
+      isPartOfTransitiveQuorumSet: vertex.isPartOfTransitiveQuorumSet,
+      ...getInitialPosition(vertex, layout),
+    })),
+    links: Array.from(viewGraph.viewEdges.values())
+      .filter((edge) => includeEdge(edge, visibleKeys, options))
+      .map((edge) => ({
+        source: edge.parent,
+        target: edge.child,
+        color: edge.color,
+        highlighted: edge.highlightAsTrusted || edge.highlightAsTrusting,
+        isFailing: edge.isFailing,
+        isPartOfStronglyConnectedComponent:
+          edge.isPartOfStronglyConnectedComponent,
+        isPartOfTransitiveQuorumSet: edge.isPartOfTransitiveQuorumSet,
+      })),
+  };
+}
+
+function includeEdge(
+  edge: ViewEdge,
+  visibleKeys: Set<string>,
+  options: Graph3DDataOptions,
+): boolean {
+  if (!visibleKeys.has(edge.parent) || !visibleKeys.has(edge.child)) {
+    return false;
+  }
+
+  if (edge.isFailing && !options.showFailingEdges) {
+    return false;
+  }
+
+  return edge.isPartOfTransitiveQuorumSet || !options.transitiveQuorumSetOnly;
+}
+
+function getNodeValue(
+  isPartOfTransitiveQuorumSet: boolean,
+  selected: boolean,
+): number {
+  if (selected) return 9;
+  return isPartOfTransitiveQuorumSet ? 7 : 4.5;
+}
+
+interface InitialLayout {
+  centerX: number;
+  centerY: number;
+  scale: number;
+}
+
+function getInitialLayout(vertices: ViewVertex[]): InitialLayout {
+  const anchorVertices = vertices.filter((vertex) => !vertex.isPerimeter);
+  const layoutVertices = anchorVertices.length > 0 ? anchorVertices : vertices;
+  const bounds = layoutVertices.reduce(
+    (currentBounds, vertex) => ({
+      minX: Math.min(currentBounds.minX, vertex.x),
+      maxX: Math.max(currentBounds.maxX, vertex.x),
+      minY: Math.min(currentBounds.minY, vertex.y),
+      maxY: Math.max(currentBounds.maxY, vertex.y),
+    }),
+    {
+      minX: Number.POSITIVE_INFINITY,
+      maxX: Number.NEGATIVE_INFINITY,
+      minY: Number.POSITIVE_INFINITY,
+      maxY: Number.NEGATIVE_INFINITY,
+    },
+  );
+  const width = Math.max(bounds.maxX - bounds.minX, 1);
+  const height = Math.max(bounds.maxY - bounds.minY, 1);
+
+  return {
+    centerX: bounds.minX + width / 2,
+    centerY: bounds.minY + height / 2,
+    scale: Math.max(width, height) / 320,
+  };
+}
+
+function getInitialPosition(vertex: ViewVertex, layout: InitialLayout) {
+  const x = (vertex.x - layout.centerX) / layout.scale;
+  const y = (vertex.y - layout.centerY) / layout.scale;
+  const z = getInitialDepth(vertex);
+  if (!vertex.isPerimeter) return { x, y, z };
+
+  return {
+    x,
+    y,
+    z,
+    fx: x,
+    fy: y,
+    fz: z,
+  };
+}
+
+function getInitialDepth(vertex: ViewVertex): number {
+  if (vertex.isPerimeter) {
+    return Math.sin(vertex.groupIndex * 1.37) * 120;
+  }
+
+  if (vertex.isPartOfTransitiveQuorumSet) {
+    return Math.sin(vertex.groupIndex * 1.19) * 34;
+  }
+
+  return Math.sin(vertex.groupIndex * 1.53) * 72;
+}

--- a/apps/frontend/src/components/visual-navigator/graph/graph-3d-forces.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/graph-3d-forces.ts
@@ -1,0 +1,47 @@
+import type { ForceGraph3DInstance } from "3d-force-graph";
+import type {
+  Graph3DLink,
+  Graph3DNode,
+} from "@/components/visual-navigator/graph/graph-3d-data";
+
+export function configureGraph3DForces(
+  graph: ForceGraph3DInstance,
+): ForceGraph3DInstance {
+  graph
+    .d3Force("charge")
+    ?.strength((node: Graph3DNode) => getChargeStrength(node));
+  graph
+    .d3Force("link")
+    ?.distance((link: Graph3DLink) => getLinkDistance(link))
+    .strength((link: Graph3DLink) => getLinkStrength(link));
+
+  return graph.d3AlphaDecay(0.028).d3VelocityDecay(0.36);
+}
+
+function getChargeStrength(node: Graph3DNode): number {
+  if (node.isPerimeter) return -56;
+  if (node.isPartOfTransitiveQuorumSet) return -185;
+  return -112;
+}
+
+function getLinkDistance(link: Graph3DLink): number {
+  if (isPerimeterLink(link)) return 210;
+  if (link.isPartOfTransitiveQuorumSet) return 78;
+  if (link.isPartOfStronglyConnectedComponent) return 104;
+  return 132;
+}
+
+function getLinkStrength(link: Graph3DLink): number {
+  if (isPerimeterLink(link)) return 0.006;
+  if (link.isPartOfTransitiveQuorumSet) return 0.044;
+  if (link.isPartOfStronglyConnectedComponent) return 0.018;
+  return 0.004;
+}
+
+function isPerimeterLink(link: Graph3DLink): boolean {
+  return isPerimeterNode(link.source) || isPerimeterNode(link.target);
+}
+
+function isPerimeterNode(node: string | Graph3DNode): boolean {
+  return typeof node !== "string" && node.isPerimeter;
+}

--- a/apps/frontend/src/components/visual-navigator/graph/graph-3d.vue
+++ b/apps/frontend/src/components/visual-navigator/graph/graph-3d.vue
@@ -1,0 +1,396 @@
+<template>
+  <div class="graph-3d-wrapper">
+    <div v-if="isRendering" class="graph-3d-loader">
+      <div class="loader"></div>
+    </div>
+    <div ref="container" class="graph-3d-canvas"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ForceGraph3D, {
+  type ForceGraph3DInstance,
+  type LinkObject,
+  type NodeObject,
+} from "3d-force-graph";
+import SpriteText from "three-spritetext";
+import {
+  AmbientLight,
+  DirectionalLight,
+  Group,
+  Mesh,
+  MeshLambertMaterial,
+  SphereGeometry,
+  type Object3D,
+} from "three";
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  toRefs,
+  watch,
+  type PropType,
+} from "vue";
+import {
+  buildGraph3DData,
+  type Graph3DData,
+  type Graph3DLink,
+  type Graph3DNode,
+} from "@/components/visual-navigator/graph/graph-3d-data";
+import { getGraph3DCameraTarget, getInitialGraph3DCameraTarget } from "@/components/visual-navigator/graph/graph-3d-camera";
+import { configureGraph3DForces } from "@/components/visual-navigator/graph/graph-3d-forces";
+import ViewGraph from "@/components/visual-navigator/graph/view-graph";
+import ViewVertex from "@/components/visual-navigator/graph/view-vertex";
+
+type Graph3DNodeCandidate = NodeObject & Partial<Graph3DNode>;
+type Graph3DLinkCandidate = LinkObject & Partial<Graph3DLink>;
+
+const props = defineProps({
+  centerVertex: {
+    type: Object as PropType<ViewVertex>,
+    required: false,
+    default: null,
+  },
+  selectedVertices: {
+    type: Array as PropType<ViewVertex[]>,
+    required: true,
+  },
+  optionShowFailingEdges: {
+    type: Boolean,
+    required: true,
+  },
+  optionHighlightTrustingNodes: {
+    type: Boolean,
+    required: true,
+  },
+  optionHighlightTrustedNodes: {
+    type: Boolean,
+    required: true,
+  },
+  optionShowRegularEdges: {
+    type: Boolean,
+    required: true,
+  },
+  optionTransitiveQuorumSetOnly: {
+    type: Boolean,
+    required: true,
+  },
+  fullScreen: {
+    type: Boolean,
+    required: true,
+  },
+  zoomEnabled: {
+    type: Boolean,
+    required: true,
+  },
+  viewGraph: {
+    type: Object as PropType<ViewGraph>,
+    required: true,
+  },
+  isLoading: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+});
+
+const {
+  centerVertex,
+  fullScreen,
+  selectedVertices,
+  optionShowFailingEdges,
+  optionTransitiveQuorumSetOnly,
+  viewGraph,
+  zoomEnabled,
+} = toRefs(props);
+const emit = defineEmits(["vertex-selected"]);
+
+const container = ref<HTMLElement | null>(null);
+const isRendering = ref(true);
+const graphData = computed(() =>
+  buildGraph3DData(viewGraph.value, {
+    showFailingEdges: optionShowFailingEdges.value,
+    transitiveQuorumSetOnly: optionTransitiveQuorumSetOnly.value,
+  }),
+);
+
+let graph: ForceGraph3DInstance | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let fitTimeout: number | null = null;
+
+watch(graphData, () => {
+  updateGraphData();
+});
+
+watch(selectedVertices, () => {
+  const selectedVertexKeys = selectedVertices.value.map((vertex) => vertex.key);
+  viewGraph.value.reClassifyEdges(selectedVertexKeys);
+  viewGraph.value.reClassifyVertices(selectedVertexKeys);
+  updateGraphData();
+});
+
+watch(zoomEnabled, () => {
+  graph?.enableNavigationControls(zoomEnabled.value);
+});
+
+watch(fullScreen, () => {
+  resizeGraph();
+  scheduleFit();
+});
+
+watch(centerVertex, () => {
+  focusCenterVertex();
+});
+
+onMounted(() => {
+  nextTick(() => {
+    createGraph();
+  });
+});
+
+onBeforeUnmount(() => {
+  if (fitTimeout !== null) {
+    window.clearTimeout(fitTimeout);
+  }
+  resizeObserver?.disconnect();
+  graph?._destructor();
+});
+
+function createGraph(): void {
+  if (!container.value) return;
+
+  const nextGraph = new ForceGraph3D(container.value, {
+    controlType: "orbit",
+    rendererConfig: { antialias: true, alpha: false, preserveDrawingBuffer: true },
+  })
+    .backgroundColor("#fbfdff")
+    .showNavInfo(false)
+    .nodeId("id")
+    .nodeVal((node) => readNode(node).val)
+    .nodeColor((node) => getNodeColor(readNode(node)))
+    .nodeThreeObject((node) => createNodeObject(readNode(node)))
+    .linkColor((link) => getLinkColor(link))
+    .linkOpacity(0.2)
+    .linkWidth((link) => getLinkWidth(link))
+    .linkDirectionalParticles((link) => (isHighlightedLink(link) ? 2 : 0))
+    .linkDirectionalParticleWidth((link) => (isHighlightedLink(link) ? 2.2 : 0))
+    .linkDirectionalParticleColor((link) => getLinkColor(link))
+    .onNodeClick((node) => {
+      const vertex = viewGraph.value.viewVertices.get(readNode(node).key);
+      if (vertex) emit("vertex-selected", vertex);
+    })
+    .onEngineStop(() => {
+      isRendering.value = false;
+      scheduleFit();
+    })
+    .enableNavigationControls(zoomEnabled.value)
+    .cooldownTicks(220)
+    .graphData(graphData.value);
+
+  graph = configureGraph3DForces(nextGraph);
+  const initialCamera = getInitialGraph3DCameraTarget();
+  nextGraph.cameraPosition(initialCamera.position, initialCamera.lookAt, 0);
+  nextGraph.lights([
+    new AmbientLight(0xffffff, 1.45),
+    createDirectionalLight(180, 120, 160),
+    createDirectionalLight(-160, -80, -140),
+  ]);
+  resizeGraph();
+  observeSize();
+  scheduleFit();
+}
+
+function updateGraphData(): void {
+  if (!graph) return;
+
+  isRendering.value = true;
+  graph.graphData(graphData.value).d3ReheatSimulation();
+  scheduleFit();
+}
+
+function createNodeObject(node: Graph3DNode): Object3D {
+  const radius = getNodeRadius(node);
+  const group = new Group();
+  const material = new MeshLambertMaterial({
+    color: getNodeColor(node),
+    transparent: true,
+    opacity: node.isPerimeter ? 0.62 : 0.96,
+  });
+  group.add(new Mesh(new SphereGeometry(radius, 16, 16), material));
+
+  if (!node.isPerimeter) {
+    const label = new SpriteText(
+      getNodeLabel(node.label),
+      node.isPartOfTransitiveQuorumSet ? 4.6 : 3.35,
+      "#244d68",
+    );
+    label.backgroundColor = "rgba(255, 255, 255, 0.86)";
+    label.borderRadius = 2;
+    label.padding = [1, 3];
+    label.fontWeight = "600";
+    label.position.y = -(radius + 3.2);
+    group.add(label);
+  }
+
+  return group;
+}
+
+function createDirectionalLight(x: number, y: number, z: number) {
+  const light = new DirectionalLight(0xffffff, 0.86);
+  light.position.set(x, y, z);
+  return light;
+}
+
+function resizeGraph(): void {
+  if (!graph || !container.value) return;
+
+  const rect = container.value.getBoundingClientRect();
+  graph.width(Math.max(1, Math.floor(rect.width)));
+  graph.height(Math.max(1, Math.floor(rect.height)));
+}
+
+function observeSize(): void {
+  if (!container.value) return;
+
+  resizeObserver = new ResizeObserver(() => {
+    resizeGraph();
+  });
+  resizeObserver.observe(container.value);
+}
+
+function scheduleFit(delay = 650): void {
+  if (fitTimeout !== null) {
+    window.clearTimeout(fitTimeout);
+  }
+
+  fitTimeout = window.setTimeout(() => {
+    fitTimeout = null;
+    const target = getGraph3DCameraTarget(graphData.value.nodes);
+    if (target) {
+      graph?.cameraPosition(target.position, target.lookAt, 650);
+      return;
+    }
+
+    graph?.zoomToFit(650, 110, (node) => !readNode(node).isPerimeter);
+  }, delay);
+}
+
+function focusCenterVertex(): void {
+  if (!graph || !centerVertex.value) return;
+
+  const graphNode = graphData.value.nodes.find(
+    (node) => node.key === centerVertex.value?.key,
+  );
+  if (!graphNode || !hasCoordinates(graphNode)) return;
+
+  graph.cameraPosition(
+    {
+      x: graphNode.x + 90,
+      y: graphNode.y + 70,
+      z: graphNode.z + 130,
+    },
+    { x: graphNode.x, y: graphNode.y, z: graphNode.z },
+    650,
+  );
+}
+
+function hasCoordinates(
+  node: Graph3DNode,
+): node is Graph3DNode & Required<Pick<Graph3DNode, "x" | "y" | "z">> {
+  return (
+    Number.isFinite(node.x) &&
+    Number.isFinite(node.y) &&
+    Number.isFinite(node.z)
+  );
+}
+
+function getNodeRadius(node: Graph3DNode): number {
+  if (node.selected) return 6.2;
+  if (node.isPartOfTransitiveQuorumSet) return 5.3;
+  if (node.isPerimeter) return 1.8;
+  return 3.8;
+}
+
+function getNodeColor(node: Graph3DNode): string {
+  if (node.isFailing) return "#d9534f";
+  if (node.selected) return "#fec601";
+  return node.color;
+}
+
+function readNode(node: NodeObject): Graph3DNode {
+  const candidate = node as Graph3DNodeCandidate;
+  const id = String(candidate.id ?? "node");
+  const key = typeof candidate.key === "string" ? candidate.key : id;
+
+  return {
+    id,
+    key,
+    label: typeof candidate.label === "string" ? candidate.label : key,
+    color: typeof candidate.color === "string" ? candidate.color : "#8f9aa7",
+    val: typeof candidate.val === "number" ? candidate.val : 4.5,
+    groupIndex:
+      typeof candidate.groupIndex === "number" ? candidate.groupIndex : 0,
+    selected: candidate.selected === true,
+    isFailing: candidate.isFailing === true,
+    isPerimeter: candidate.isPerimeter === true,
+    isPartOfTransitiveQuorumSet: candidate.isPartOfTransitiveQuorumSet === true,
+    x: candidate.x,
+    y: candidate.y,
+    z: candidate.z,
+  };
+}
+
+function readLink(link: LinkObject): Graph3DLinkCandidate {
+  return link as Graph3DLinkCandidate;
+}
+
+function getLinkColor(link: LinkObject): string {
+  const candidate = readLink(link);
+  if (candidate.isFailing) return "#d9534f";
+  if (candidate.highlighted) return "#00a6a6";
+  return typeof candidate.color === "string" ? candidate.color : "#9dbfd3";
+}
+
+function getLinkWidth(link: LinkObject): number {
+  const candidate = readLink(link);
+  if (candidate.highlighted) return 2.2;
+  if (candidate.isPartOfStronglyConnectedComponent) return 1.15;
+  return 0.5;
+}
+
+function isHighlightedLink(link: LinkObject): boolean {
+  return readLink(link).highlighted === true;
+}
+
+function getNodeLabel(label: string): string {
+  if (label.length <= 12) return label;
+  return `${label.slice(0, 10)}...`;
+}
+</script>
+
+<style scoped>
+.graph-3d-wrapper {
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  background: #fbfdff;
+}
+
+.graph-3d-canvas {
+  height: 100%;
+  width: 100%;
+}
+
+.graph-3d-loader {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  background: rgba(251, 253, 255, 0.48);
+}
+</style>

--- a/apps/frontend/src/components/visual-navigator/graph/graph-display.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/graph-display.ts
@@ -3,6 +3,8 @@ import ViewEdge from "@/components/visual-navigator/graph/view-edge";
 import ViewGraph from "@/components/visual-navigator/graph/view-graph";
 import ViewVertex from "@/components/visual-navigator/graph/view-vertex";
 
+const maxVertexLabelLength = 11;
+
 export interface GraphDisplayContext {
   selectedVertices: Ref<ViewVertex[]>;
   viewGraph: Ref<ViewGraph>;
@@ -20,6 +22,13 @@ export function getVertexRadius(vertex: ViewVertex): number {
   if (vertex.isPartOfTransitiveQuorumSet) return 11.5;
   if (vertex.isPerimeter) return 8;
   return 9.5;
+}
+
+export function getVertexLabel(
+  vertex: ViewVertex,
+  truncate: (value: string, length: number) => string,
+): string {
+  return truncate(vertex.label, maxVertexLabelLength);
 }
 
 export function getVertexStyle(vertex: ViewVertex): Record<string, string> {
@@ -93,7 +102,7 @@ function getVertexTextRectWidth(
   vertex: ViewVertex,
   truncate: (value: string, length: number) => string,
 ): number {
-  return Math.max(44, truncate(vertex.label, 14).length * 6.2 + 10);
+  return Math.max(32, getVertexLabel(vertex, truncate).length * 4.7 + 8);
 }
 
 function highlightVertexAsOutgoing(

--- a/apps/frontend/src/components/visual-navigator/graph/graph-display.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/graph-display.ts
@@ -16,9 +16,10 @@ export function getVertexTransform(vertex: ViewVertex): string {
 }
 
 export function getVertexRadius(vertex: ViewVertex): number {
-  if (vertex.selected) return 13;
-  if (vertex.isPartOfTransitiveQuorumSet) return 10;
-  return 8.5;
+  if (vertex.selected) return 14.5;
+  if (vertex.isPartOfTransitiveQuorumSet) return 11.5;
+  if (vertex.isPerimeter) return 8;
+  return 9.5;
 }
 
 export function getVertexStyle(vertex: ViewVertex): Record<string, string> {
@@ -92,7 +93,7 @@ function getVertexTextRectWidth(
   vertex: ViewVertex,
   truncate: (value: string, length: number) => string,
 ): number {
-  return Math.max(36, truncate(vertex.label, 12).length * 5.5 + 8);
+  return Math.max(44, truncate(vertex.label, 14).length * 6.2 + 10);
 }
 
 function highlightVertexAsOutgoing(

--- a/apps/frontend/src/components/visual-navigator/graph/graph-mode.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/graph-mode.ts
@@ -1,0 +1,1 @@
+export type GraphVisualizationMode = "2d" | "3d";

--- a/apps/frontend/src/components/visual-navigator/graph/graph.scss
+++ b/apps/frontend/src/components/visual-navigator/graph/graph.scss
@@ -98,11 +98,11 @@ circle {
 
 text {
   fill: #244d68;
-  font-weight: 500;
+  font-weight: 600;
   paint-order: stroke;
   stroke: white;
   stroke-linejoin: round;
-  stroke-width: 1.9px;
+  stroke-width: 1.6px;
 }
 
 .vertex-label {
@@ -113,8 +113,8 @@ text {
   opacity: 0;
 }
 
-.secondary-vertex .vertex-label {
-  opacity: 0;
+.secondary-vertex:not(.perimeter-vertex) .vertex-label {
+  opacity: 0.78;
 }
 
 .perimeter-vertex:hover .vertex-label,
@@ -139,7 +139,7 @@ text {
 
 .vertex-label-background {
   fill: white;
-  opacity: 0.92;
+  opacity: 0.86;
   text-transform: lowercase;
 }
 

--- a/apps/frontend/src/components/visual-navigator/graph/graph.scss
+++ b/apps/frontend/src/components/visual-navigator/graph/graph.scss
@@ -5,7 +5,12 @@ svg.graph {
   cursor: grab;
   touch-action: none;
   overscroll-behavior: contain;
+  overflow: hidden;
   background: #fbfdff;
+}
+
+.svg-wrapper {
+  overflow: hidden;
 }
 
 .dimmer.active .dimmer-content {

--- a/apps/frontend/src/components/visual-navigator/graph/graph.scss
+++ b/apps/frontend/src/components/visual-navigator/graph/graph.scss
@@ -15,14 +15,14 @@ svg.graph {
 path.edge {
   stroke: var(--edge-color, $graph-primary);
   stroke-width: 0.7px;
-  stroke-opacity: 0.16;
+  stroke-opacity: 0.12;
   fill-opacity: 0;
 }
 
 path.strongly-connected {
   stroke: var(--edge-color, $graph-primary);
   stroke-width: 1.1px;
-  stroke-opacity: 0.44;
+  stroke-opacity: 0.5;
 }
 
 path.failing {
@@ -88,16 +88,35 @@ circle {
   stroke: $white;
   fill: $gray-100;
   cursor: pointer;
-  stroke-width: 1.75px;
+  stroke-width: 2px;
 }
 
 text {
-  fill: #2f5f7c;
-  font-weight: 400;
+  fill: #244d68;
+  font-weight: 500;
   paint-order: stroke;
   stroke: white;
   stroke-linejoin: round;
-  stroke-width: 1.6px;
+  stroke-width: 1.9px;
+}
+
+.vertex-label {
+  transition: opacity 120ms ease-in-out;
+}
+
+.perimeter-vertex .vertex-label {
+  opacity: 0;
+}
+
+.secondary-vertex .vertex-label {
+  opacity: 0;
+}
+
+.perimeter-vertex:hover .vertex-label,
+.perimeter-vertex:focus .vertex-label,
+.secondary-vertex:hover .vertex-label,
+.secondary-vertex:focus .vertex-label {
+  opacity: 1;
 }
 
 .failing {
@@ -110,7 +129,13 @@ text {
 }
 
 .rect {
-  opacity: 0.8;
+  opacity: 0.9;
+}
+
+.vertex-label-background {
+  fill: white;
+  opacity: 0.92;
+  text-transform: lowercase;
 }
 
 .rect-selected {

--- a/apps/frontend/src/components/visual-navigator/graph/graph.vue
+++ b/apps/frontend/src/components/visual-navigator/graph/graph.vue
@@ -135,6 +135,11 @@
               :key="vertex.key"
               :transform="getVertexTransform(vertex)"
               class="vertex"
+              :class="{
+                'perimeter-vertex': vertex.isPerimeter,
+                'secondary-vertex':
+                  !vertex.isPartOfTransitiveQuorumSet && !vertex.selected,
+              }"
               style="cursor: pointer"
               @click="
                 vertexSelected(vertex);
@@ -148,14 +153,14 @@
               >
                 <title>{{ vertex.label }}</title>
               </circle>
-              <g>
+              <g class="vertex-label">
                 <rect
-                  style="fill: white; opacity: 0.84; text-transform: lowercase"
+                  class="vertex-label-background"
                   :width="getVertexTextRectWidthPx(vertex)"
-                  height="12px"
-                  y="13"
+                  height="15px"
+                  y="14"
                   :x="getVertexTextRectX(vertex)"
-                  rx="2"
+                  rx="3"
                   :class="{
                     'rect-selected': vertex.selected,
                     rect: !vertex.selected,
@@ -164,11 +169,11 @@
                 <text
                   y="5"
                   :class="getVertexTextClass(vertex)"
-                  dy="1.7em"
+                  dy="1.9em"
                   text-anchor="middle"
-                  font-size="9px"
+                  font-size="10.5px"
                 >
-                  {{ truncate(vertex.label, 12) }}
+                  {{ truncate(vertex.label, 14) }}
                   <title>{{ vertex.label }}</title>
                 </text>
               </g>

--- a/apps/frontend/src/components/visual-navigator/graph/graph.vue
+++ b/apps/frontend/src/components/visual-navigator/graph/graph.vue
@@ -157,8 +157,8 @@
                 <rect
                   class="vertex-label-background"
                   :width="getVertexTextRectWidthPx(vertex)"
-                  height="15px"
-                  y="14"
+                  height="12px"
+                  y="11"
                   :x="getVertexTextRectX(vertex)"
                   rx="3"
                   :class="{
@@ -167,13 +167,13 @@
                   }"
                 ></rect>
                 <text
-                  y="5"
+                  y="3"
                   :class="getVertexTextClass(vertex)"
-                  dy="1.9em"
+                  dy="1.75em"
                   text-anchor="middle"
-                  font-size="10.5px"
+                  font-size="7.8px"
                 >
-                  {{ truncate(vertex.label, 14) }}
+                  {{ getVertexLabel(vertex) }}
                   <title>{{ vertex.label }}</title>
                 </text>
               </g>
@@ -196,6 +196,7 @@ import {
   getEdgePath,
   getEdgeStyle,
   getVertexClassObject as buildVertexClassObject,
+  getVertexLabel as buildVertexLabel,
   getVertexRadius,
   getVertexStyle as buildVertexStyle,
   getVertexTextClass,
@@ -346,6 +347,10 @@ function getVertexTextRectWidthPx(vertex: ViewVertex): string {
 
 function getVertexTextRectX(vertex: ViewVertex): string {
   return buildVertexTextRectX(vertex, truncate);
+}
+
+function getVertexLabel(vertex: ViewVertex): string {
+  return buildVertexLabel(vertex, truncate);
 }
 </script>
 

--- a/apps/frontend/src/components/visual-navigator/graph/use-graph-controller.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/use-graph-controller.ts
@@ -146,6 +146,7 @@ export function useGraphController(options: GraphControllerOptions) {
       if (!vertex) return;
       vertex.x = updatedVertex.x;
       vertex.y = updatedVertex.y;
+      vertex.isPerimeter = updatedVertex.isPerimeter;
     });
 
     edges.forEach((updatedEdge) => {

--- a/apps/frontend/src/components/visual-navigator/graph/view-vertex.ts
+++ b/apps/frontend/src/components/visual-navigator/graph/view-vertex.ts
@@ -11,6 +11,7 @@ export default class ViewVertex {
   isTrustedBySelectedVertex = false;
   selected = false;
   isFailing = false;
+  isPerimeter = false;
   groupKey: string | null = null;
   groupIndex = 0;
   color = getGraphGroupColor(null);

--- a/apps/frontend/src/components/visual-navigator/network-graph-card.vue
+++ b/apps/frontend/src/components/visual-navigator/network-graph-card.vue
@@ -1,5 +1,22 @@
 <template>
-  <Graph
+  <Graph3D
+    v-if="graphMode === '3d'"
+    :center-vertex="centerVertex"
+    :selected-vertices="selectedVertices"
+    style="height: 100%"
+    :full-screen="fullScreen"
+    :zoom-enabled="zoomEnabled"
+    :view-graph="viewGraph"
+    :is-loading="isLoading"
+    :option-show-failing-edges="optionShowFailingEdges"
+    :option-highlight-trusting-nodes="optionHighlightTrustingNodes"
+    :option-highlight-trusted-nodes="optionHighlightTrustedNodes"
+    :option-show-regular-edges="optionShowRegularEdges"
+    :option-transitive-quorum-set-only="optionTransitiveQuorumSetOnly"
+    @vertex-selected="vertexSelected"
+  />
+  <Graph2D
+    v-else
     ref="graph"
     :center-vertex="centerVertex"
     :selected-vertices="selectedVertices"
@@ -19,16 +36,18 @@
 </template>
 
 <script setup lang="ts">
-import Graph from "@/components/visual-navigator/graph/graph.vue";
+import Graph2D from "@/components/visual-navigator/graph/graph.vue";
 import ViewGraph from "@/components/visual-navigator/graph/view-graph";
 import ViewVertex from "@/components/visual-navigator/graph/view-vertex";
 import {
   computed,
+  defineAsyncComponent,
   type ComputedRef,
   onMounted,
   type Ref,
   ref,
   watch,
+  type PropType,
 } from "vue";
 import useStore from "@/store/useStore";
 import { useRoute, useRouter } from "vue-router/composables";
@@ -36,6 +55,11 @@ import { NodeTrustGraphBuilder } from "@/services/NodeTrustGraphBuilder";
 import { OrganizationTrustGraphBuilder } from "@/services/OrganizationTrustGraphBuilder";
 import { TrustClusterFinder } from "@/services/TrustClusterFinder";
 import { Node, Organization } from "shared";
+import type { GraphVisualizationMode } from "@/components/visual-navigator/graph/graph-mode";
+
+const Graph3D = defineAsyncComponent(
+  () => import("@/components/visual-navigator/graph/graph-3d.vue"),
+);
 
 const router = useRouter();
 const route = useRoute();
@@ -80,9 +104,14 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  graphMode: {
+    type: String as PropType<GraphVisualizationMode>,
+    default: "2d",
+  },
 });
 
 const type = computed(() => props.type);
+const graphMode = computed(() => props.graphMode);
 const includeAllNodes = computed(() => store.includeAllNodes);
 const selectedNode = computed(() => store.selectedNode);
 const selectedOrganization = computed(() => store.selectedOrganization);
@@ -232,11 +261,18 @@ function buildOrganizationViewGraph(allNodes: Node[], merge: boolean) {
                 store.selectedOrganization.validators.map((publicKey) =>
                   store.network.getNodeByPublicKey(publicKey),
                 ),
-                new Map(allNodes.map((node) => [node.publicKey, node.quorumSet])),
+                new Map(
+                  allNodes.map((node) => [node.publicKey, node.quorumSet]),
+                ),
               ),
             )
-              .map((node) => store.network.getNodeByPublicKey(node).organizationId)
-              .filter((organizationId): organizationId is string => organizationId !== null)
+              .map(
+                (node) => store.network.getNodeByPublicKey(node).organizationId,
+              )
+              .filter(
+                (organizationId): organizationId is string =>
+                  organizationId !== null,
+              )
               .map((organizationId) =>
                 store.network.getOrganizationById(organizationId),
               ),

--- a/apps/frontend/src/components/visual-navigator/network-visual-navigator.scss
+++ b/apps/frontend/src/components/visual-navigator/network-visual-navigator.scss
@@ -1,0 +1,124 @@
+.sb-bread-crumbs {
+  background: white !important;
+  margin: 0;
+  padding: 0;
+  align-self: center;
+}
+
+.sb-card-fullscreen {
+  z-index: 4;
+  height: 100% !important;
+}
+
+.network-visual-navigator {
+  height: min(88vh, 1040px);
+  min-height: 760px;
+}
+
+@media (max-width: 768px) {
+  .network-visual-navigator {
+    height: 78vh;
+    min-height: 600px;
+  }
+}
+
+.collapse-icon {
+  cursor: pointer;
+  position: absolute;
+  right: 8px;
+  top: 10px;
+}
+
+.menu {
+  z-index: 5000;
+  position: absolute;
+  background: white;
+  width: 250px;
+  height: 100%;
+}
+
+.menu-button {
+  cursor: pointer;
+}
+
+.view-link {
+  text-decoration: none;
+  padding-left: 7px;
+  color: #818181;
+  cursor: pointer;
+}
+
+.view-link a {
+  text-decoration: none;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.view-link:hover {
+  background-color: #f8f9fa;
+  text-decoration: none;
+}
+
+.router-link-exact-active {
+  color: #206bc4 !important;
+  text-decoration: none;
+  background-color: rgba(32, 107, 196, 0.06);
+}
+
+.graph-mode-toggle .btn {
+  min-width: 38px;
+  padding: 0.15rem 0.48rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.graph-mode-toggle .btn.active {
+  color: white;
+  background: #4d9ccf;
+  border-color: #4d9ccf;
+}
+
+.preview-text {
+  position: absolute;
+  bottom: 0;
+  height: 25px;
+  color: white;
+  width: 100%;
+  text-align: center;
+  border-radius: 5px;
+  background: linear-gradient(
+    0deg,
+    rgba(67, 104, 113, 1) 0%,
+    rgba(170, 211, 223, 1) 100%
+  );
+}
+
+.preview-image {
+  border-radius: 5px;
+}
+
+.preview {
+  z-index: 1000;
+  position: absolute;
+  left: 10px;
+  bottom: 10px;
+  width: 60px;
+  height: 60px;
+  border-radius: 5px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  background: white;
+}
+
+.sb-bread-crumbs-container {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+}
+
+.world-loader {
+  position: absolute;
+  left: 50%;
+  right: 50%;
+  top: 30%;
+}

--- a/apps/frontend/src/components/visual-navigator/network-visual-navigator.vue
+++ b/apps/frontend/src/components/visual-navigator/network-visual-navigator.vue
@@ -152,6 +152,29 @@
         <b-breadcrumb class="sb-bread-crumbs" :items="breadCrumbs">
         </b-breadcrumb>
       </div>
+      <div
+        v-if="isGraphView"
+        class="btn-group btn-group-sm graph-mode-toggle ml-auto mr-2"
+        role="group"
+        aria-label="Graph display mode"
+      >
+        <button
+          type="button"
+          class="btn btn-outline-secondary"
+          :class="{ active: graphMode === '2d' }"
+          @click="graphMode = '2d'"
+        >
+          2D
+        </button>
+        <button
+          type="button"
+          class="btn btn-outline-secondary"
+          :class="{ active: graphMode === '3d' }"
+          @click="graphMode = '3d'"
+        >
+          3D
+        </button>
+      </div>
       <a
         v-if="!zoomEnabled"
         v-tooltip="'Toggle scroll to zoom'"
@@ -214,6 +237,7 @@
         :option-show-regular-edges="optionShowRegularEdges"
         :option-transitive-quorum-set-only="optionTransitiveQuorumSetOnly"
         :option-filter-trust-cluster="optionFilterTrustCluster"
+        :graph-mode="graphMode"
         :type="view === 'graph' ? 'node' : 'organization'"
       >
       </network-graph-card>
@@ -256,6 +280,7 @@ import GraphLegend from "@/components/visual-navigator/graph/graph-legend.vue";
 import useStore from "@/store/useStore";
 import { useRoute, useRouter } from "vue-router/composables";
 import { isString } from "shared";
+import type { GraphVisualizationMode } from "@/components/visual-navigator/graph/graph-mode";
 
 const WorldMap = defineAsyncComponent(
   () => import("@/components/visual-navigator/world-map.vue"),
@@ -268,6 +293,9 @@ const props = defineProps({
   },
 });
 const view = computed(() => props.view);
+const isGraphView = computed(
+  () => view.value === "graph" || view.value === "graph-org",
+);
 
 const store = useStore();
 const network = store.network;
@@ -292,6 +320,7 @@ const optionFilterTrustCluster = ref(false);
 const menuVisible = ref(false);
 const fullScreen = ref(false);
 const zoomEnabled = ref(true);
+const graphMode = ref<GraphVisualizationMode>("2d");
 
 const breadCrumbs = computed(() => {
   const crumbs: {
@@ -368,122 +397,4 @@ function navigateToView() {
   });
 }
 </script>
-<style scoped>
-.sb-bread-crumbs {
-  background: white !important;
-  margin: 0;
-  padding: 0;
-  align-self: center;
-}
-
-.sb-card-fullscreen {
-  z-index: 4;
-  height: 100% !important;
-}
-
-.network-visual-navigator {
-  height: min(88vh, 1040px);
-  min-height: 760px;
-}
-
-@media (max-width: 768px) {
-  .network-visual-navigator {
-    height: 78vh;
-    min-height: 600px;
-  }
-}
-
-.collapse-icon {
-  cursor: pointer;
-  position: absolute;
-  right: 8px;
-  top: 10px;
-}
-
-.menu {
-  z-index: 5000;
-  position: absolute;
-  background: white;
-  width: 250px;
-  height: 100%;
-}
-
-.menu-button {
-  cursor: pointer;
-}
-
-.view-link {
-  text-decoration: none;
-  padding-left: 7px;
-  color: #818181;
-  cursor: pointer;
-}
-
-.view-link a {
-  text-decoration: none;
-  color: rgba(0, 0, 0, 0.55);
-}
-
-.view-link:hover {
-  background-color: #f8f9fa;
-  text-decoration: none;
-}
-
-.router-link-exact-active {
-  color: #206bc4 !important;
-  text-decoration: none;
-  background-color: rgba(32, 107, 196, 0.06);
-}
-
-.preview-text {
-  position: absolute;
-  bottom: 0;
-  height: 25px;
-  color: white;
-  width: 100%;
-  text-align: center;
-  border-radius: 5px;
-  background: linear-gradient(
-    0deg,
-    rgba(67, 104, 113, 1) 0%,
-    rgba(170, 211, 223, 1) 100%
-  );
-}
-
-.preview-image {
-  border-radius: 5px;
-}
-
-.preview {
-  z-index: 1000;
-  position: absolute;
-  left: 10px;
-  bottom: 10px;
-  width: 60px;
-  height: 60px;
-  border-radius: 5px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
-  cursor: pointer;
-  background: white;
-}
-
-.sb-bread-crumbs {
-  background-color: white;
-  margin: 0;
-  padding: 0;
-  align-self: center;
-}
-
-.sb-bread-crumbs-container {
-  display: flex;
-  flex-grow: 1;
-  align-items: center;
-}
-
-.world-loader {
-  position: absolute;
-  left: 50%;
-  right: 50%;
-  top: 30%;
-}
-</style>
+<style lang="scss" scoped src="./network-visual-navigator.scss"></style>

--- a/apps/frontend/src/views/Dashboard.vue
+++ b/apps/frontend/src/views/Dashboard.vue
@@ -49,16 +49,16 @@
         </HaltingAnalysis>
       </div>
     </div>
-    <div class="row h-100">
-      <aside class="col-xs-12 col-sm-5 col-lg-3 col-xl-auto mb-5">
+    <div class="dashboard-shell h-100">
+      <aside class="dashboard-sidebar mb-5">
         <div class="card pt-0 sidebar-card h-100">
           <transition name="fade" mode="out-in">
             <router-view name="sideBar" class="h-100 side-bar" />
           </transition>
         </div>
       </aside>
-      <div id="content" class="col-sm-7 col-lg-9 col-xl">
-        <div class="row">
+      <div id="content" class="dashboard-content">
+        <div class="row navigator-row">
           <div class="col">
             <network-visual-navigator :view="view" />
           </div>
@@ -166,7 +166,49 @@ watch(haltingAnalysisPublicKey, (publicKey) => {
 </script>
 
 <style scoped>
+.dashboard-shell {
+  display: block;
+  position: relative;
+}
+
+.dashboard-sidebar {
+  width: 100%;
+}
+
 @media (min-width: 1279px) {
+  .dashboard-sidebar {
+    left: 0;
+    margin-bottom: 0 !important;
+    position: absolute;
+    top: 0;
+    width: 292px;
+    z-index: 5;
+  }
+
+  .sidebar-card {
+    backdrop-filter: blur(8px);
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: 0 12px 35px rgba(44, 62, 80, 0.12);
+    height: min(88vh, 1040px) !important;
+    max-height: 1040px;
+    overflow: hidden;
+  }
+
+  .dashboard-content {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .navigator-row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .navigator-row > .col {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   .side-bar {
     width: 272px;
   }

--- a/apps/frontend/src/workers/compute-graphv9.worker.ts
+++ b/apps/frontend/src/workers/compute-graphv9.worker.ts
@@ -152,7 +152,7 @@ ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
     simulatedVertices,
     getSimulatedVertexBounds(layoutBounds, perimeterVertices.length),
   );
-  placePerimeterVertices(perimeterVertices, layoutBounds);
+  placePerimeterVertices(perimeterVertices, layoutBounds, width, height);
   hydrateEdgeEndpoints(edges, vertexByKey);
   ctx.postMessage({ type: "end", vertices: vertices, edges: edges });
 });
@@ -246,19 +246,58 @@ function getPerimeterVertices(
 function placePerimeterVertices(
   vertices: GraphNodeDatum[],
   bounds: LayoutBounds,
+  viewportWidth: number,
+  viewportHeight: number,
 ): void {
   if (vertices.length === 0) return;
 
-  const columns = Math.max(8, Math.ceil(Math.sqrt(vertices.length)));
-  const startX = bounds.right + 180;
-  const startY = bounds.top + 48;
-  const columnGap = 48;
-  const rowGap = 38;
+  const center = centerOf(bounds);
+  const baseRadius = farthestViewportCornerDistance(
+    center,
+    viewportWidth,
+    viewportHeight,
+  );
+  const ringGap = 78;
+  const minimumCircleSpacing = 42;
+  let vertexIndex = 0;
+  let ringIndex = 0;
 
-  vertices.forEach((vertex, index) => {
-    vertex.x = startX + (index % columns) * columnGap;
-    vertex.y = startY + Math.floor(index / columns) * rowGap;
-  });
+  while (vertexIndex < vertices.length) {
+    const radius = baseRadius + 96 + ringIndex * ringGap;
+    const ringCapacity = Math.max(
+      16,
+      Math.floor((Math.PI * 2 * radius) / minimumCircleSpacing),
+    );
+    const verticesOnRing = Math.min(
+      vertices.length - vertexIndex,
+      ringCapacity,
+    );
+    const angleOffset =
+      -Math.PI / 2 + (ringIndex % 2) * (Math.PI / verticesOnRing);
+
+    for (let step = 0; step < verticesOnRing; step += 1) {
+      const vertex = vertices[vertexIndex];
+      const angle = angleOffset + (step / verticesOnRing) * Math.PI * 2;
+      vertex.x = center.x + Math.cos(angle) * radius;
+      vertex.y = center.y + Math.sin(angle) * radius;
+      vertexIndex += 1;
+    }
+
+    ringIndex += 1;
+  }
+}
+
+function farthestViewportCornerDistance(
+  center: Point,
+  viewportWidth: number,
+  viewportHeight: number,
+): number {
+  return Math.max(
+    Math.hypot(center.x, center.y),
+    Math.hypot(viewportWidth - center.x, center.y),
+    Math.hypot(center.x, viewportHeight - center.y),
+    Math.hypot(viewportWidth - center.x, viewportHeight - center.y),
+  );
 }
 
 function fitVerticesToBounds(

--- a/apps/frontend/src/workers/compute-graphv9.worker.ts
+++ b/apps/frontend/src/workers/compute-graphv9.worker.ts
@@ -1,5 +1,6 @@
 import {
   forceCenter,
+  forceCollide,
   forceLink,
   forceManyBody,
   forceSimulation,
@@ -35,6 +36,18 @@ type GraphWorkerScope = {
   postMessage: (message: GraphWorkerResponse) => void;
 };
 
+type LayoutBounds = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
+
+type Point = {
+  x: number;
+  y: number;
+};
+
 const ctx = self as GraphWorkerScope;
 
 ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
@@ -42,57 +55,85 @@ ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
   const edges = event.data.edges as GraphLinkDatum[];
   const width = event.data.width;
   const height = event.data.height;
+  const vertexByKey = new Map(vertices.map((vertex) => [vertex.key, vertex]));
+  const layoutBounds = getLayoutBounds(width, height);
+  const graphCenter = centerOf(layoutBounds);
+  const degrees = getVertexDegrees(edges);
+  const perimeterVertices = getPerimeterVertices(vertices, degrees);
+  const perimeterVertexKeys = new Set(
+    perimeterVertices.map((vertex) => vertex.key),
+  );
+  vertices.forEach((vertex) => {
+    vertex.isPerimeter = perimeterVertexKeys.has(vertex.key);
+  });
+  const simulatedVertices = vertices.filter(
+    (vertex) => !perimeterVertexKeys.has(vertex.key),
+  );
+  const simulatedEdges = edges.filter(
+    (edge) =>
+      !perimeterVertexKeys.has(endpointKey(edge.source)) &&
+      !perimeterVertexKeys.has(endpointKey(edge.target)),
+  );
 
   const nrOfTransitiveVertices = Math.max(
-    vertices.filter((vertex) => vertex.isPartOfTransitiveQuorumSet).length,
+    simulatedVertices.filter((vertex) => vertex.isPartOfTransitiveQuorumSet)
+      .length,
     1,
   );
   const nrOfGroups = Math.max(
-    new Set(vertices.map((vertex) => vertex.groupIndex)).size,
+    new Set(simulatedVertices.map((vertex) => vertex.groupIndex)).size,
     1,
   );
-  const groupCenterRadius = Math.min(width, height) * 0.42;
+  const groupCenterRadius =
+    Math.min(widthOf(layoutBounds), heightOf(layoutBounds)) * 0.43;
 
-  const simulation = forceSimulation<GraphNodeDatum>(vertices)
+  const simulation = forceSimulation<GraphNodeDatum>(simulatedVertices)
     .force(
       "charge",
       forceManyBody<GraphNodeDatum>().strength((vertex) => {
-        return vertex.isPartOfTransitiveQuorumSet ? -760 : -430;
+        return vertex.isPartOfTransitiveQuorumSet ? -760 : -420;
       }),
     )
     .force(
       "link",
-      forceLink<GraphNodeDatum, GraphLinkDatum>(edges)
+      forceLink<GraphNodeDatum, GraphLinkDatum>(simulatedEdges)
         .distance((edge) => {
-          return edge.isPartOfTransitiveQuorumSet ? 110 : 175;
+          return edge.isPartOfTransitiveQuorumSet ? 112 : 170;
         })
         .strength((edge: SimulationLinkDatum<GraphNodeDatum>) => {
           const viewEdge = edge as GraphLinkDatum;
           if (viewEdge.isPartOfTransitiveQuorumSet) {
-            return (1 / nrOfTransitiveVertices) * 0.17;
+            return (1 / nrOfTransitiveVertices) * 0.2;
           } else if (viewEdge.isPartOfStronglyConnectedComponent) {
-            return 0.1;
+            return 0.11;
           } else {
-            return 0.004;
+            return 0.006;
           }
         })
         .id((vertex) => vertex.key),
     )
     .force(
+      "collision",
+      forceCollide<GraphNodeDatum>()
+        .radius((vertex) => (vertex.isPartOfTransitiveQuorumSet ? 34 : 22))
+        .strength(0.72)
+        .iterations(2),
+    )
+    .force(
       "x",
       forceX<GraphNodeDatum>(
         (vertex) =>
-          groupCenter(vertex, nrOfGroups, width, height, groupCenterRadius).x,
-      ).strength(0.12),
+          groupCenter(vertex, nrOfGroups, graphCenter, groupCenterRadius).x,
+      ).strength(0.11),
     )
     .force(
       "y",
       forceY<GraphNodeDatum>(
         (vertex) =>
-          groupCenter(vertex, nrOfGroups, width, height, groupCenterRadius).y,
-      ).strength(0.12),
+          groupCenter(vertex, nrOfGroups, graphCenter, groupCenterRadius).y,
+      ).strength(0.11),
     )
-    .force("center", forceCenter(width / 2, height / 2))
+    .force("center", forceCenter(graphCenter.x, graphCenter.y))
     .velocityDecay(0.38)
     .stop();
 
@@ -107,25 +148,173 @@ ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
     //ctx.postMessage({type: 'tick', progress: i / n});
     simulation.tick();
   }
+  fitVerticesToBounds(
+    simulatedVertices,
+    getSimulatedVertexBounds(layoutBounds, perimeterVertices.length),
+  );
+  placePerimeterVertices(perimeterVertices, layoutBounds);
+  hydrateEdgeEndpoints(edges, vertexByKey);
   ctx.postMessage({ type: "end", vertices: vertices, edges: edges });
 });
 
 function groupCenter(
   vertex: GraphNodeDatum,
   nrOfGroups: number,
-  width: number,
-  height = width,
-  radius = Math.min(width, height) * 0.34,
+  center: Point,
+  radius: number,
 ): { x: number; y: number } {
   if (nrOfGroups <= 1) {
-    return { x: width / 2, y: height / 2 };
+    return center;
   }
 
   const angle = (vertex.groupIndex / nrOfGroups) * Math.PI * 2;
   return {
-    x: width / 2 + Math.cos(angle) * radius,
-    y: height / 2 + Math.sin(angle) * radius,
+    x: center.x + Math.cos(angle) * radius,
+    y: center.y + Math.sin(angle) * radius,
   };
+}
+
+function getLayoutBounds(width: number, height: number): LayoutBounds {
+  const overlayMargin = width >= 992 ? Math.min(300, width * 0.24) : 24;
+
+  return {
+    left: overlayMargin + 30,
+    right: Math.max(overlayMargin + 120, width - 36),
+    top: 36,
+    bottom: Math.max(160, height - 42),
+  };
+}
+
+function getSimulatedVertexBounds(
+  bounds: LayoutBounds,
+  perimeterVertexCount: number,
+): LayoutBounds {
+  const perimeterPadding = perimeterVertexCount > 0 ? 34 : 40;
+
+  return {
+    left: bounds.left + 30,
+    right: bounds.right - perimeterPadding,
+    top: bounds.top + 30,
+    bottom: bounds.bottom - Math.max(30, perimeterPadding),
+  };
+}
+
+function centerOf(bounds: LayoutBounds): Point {
+  return {
+    x: bounds.left + widthOf(bounds) / 2,
+    y: bounds.top + heightOf(bounds) / 2,
+  };
+}
+
+function widthOf(bounds: LayoutBounds): number {
+  return bounds.right - bounds.left;
+}
+
+function heightOf(bounds: LayoutBounds): number {
+  return bounds.bottom - bounds.top;
+}
+
+function getVertexDegrees(edges: GraphLinkDatum[]): Map<string, number> {
+  const degrees = new Map<string, number>();
+  edges.forEach((edge) => {
+    incrementDegree(degrees, endpointKey(edge.source));
+    incrementDegree(degrees, endpointKey(edge.target));
+  });
+
+  return degrees;
+}
+
+function incrementDegree(degrees: Map<string, number>, key: string): void {
+  degrees.set(key, (degrees.get(key) ?? 0) + 1);
+}
+
+function getPerimeterVertices(
+  vertices: GraphNodeDatum[],
+  degrees: Map<string, number>,
+): GraphNodeDatum[] {
+  if (vertices.length < 24) return [];
+
+  return vertices
+    .filter(
+      (vertex) =>
+        !vertex.isPartOfTransitiveQuorumSet &&
+        (degrees.get(vertex.key) ?? 0) === 0,
+    )
+    .sort((first, second) => first.label.localeCompare(second.label));
+}
+
+function placePerimeterVertices(
+  vertices: GraphNodeDatum[],
+  bounds: LayoutBounds,
+): void {
+  if (vertices.length === 0) return;
+
+  const columns = Math.max(8, Math.ceil(Math.sqrt(vertices.length)));
+  const startX = bounds.right + 180;
+  const startY = bounds.top + 48;
+  const columnGap = 48;
+  const rowGap = 38;
+
+  vertices.forEach((vertex, index) => {
+    vertex.x = startX + (index % columns) * columnGap;
+    vertex.y = startY + Math.floor(index / columns) * rowGap;
+  });
+}
+
+function fitVerticesToBounds(
+  vertices: GraphNodeDatum[],
+  bounds: LayoutBounds,
+): void {
+  if (vertices.length === 0) return;
+
+  const extent = vertices.reduce(
+    (currentExtent, vertex) => {
+      return {
+        left: Math.min(currentExtent.left, vertex.x ?? 0),
+        right: Math.max(currentExtent.right, vertex.x ?? 0),
+        top: Math.min(currentExtent.top, vertex.y ?? 0),
+        bottom: Math.max(currentExtent.bottom, vertex.y ?? 0),
+      };
+    },
+    {
+      left: Number.POSITIVE_INFINITY,
+      right: Number.NEGATIVE_INFINITY,
+      top: Number.POSITIVE_INFINITY,
+      bottom: Number.NEGATIVE_INFINITY,
+    },
+  );
+
+  const extentWidth = Math.max(extent.right - extent.left, 1);
+  const extentHeight = Math.max(extent.bottom - extent.top, 1);
+  const scale = Math.min(
+    widthOf(bounds) / extentWidth,
+    heightOf(bounds) / extentHeight,
+    1.08,
+  );
+  const targetCenter = centerOf(bounds);
+  const extentCenter = {
+    x: extent.left + extentWidth / 2,
+    y: extent.top + extentHeight / 2,
+  };
+
+  vertices.forEach((vertex) => {
+    vertex.x = targetCenter.x + ((vertex.x ?? 0) - extentCenter.x) * scale;
+    vertex.y = targetCenter.y + ((vertex.y ?? 0) - extentCenter.y) * scale;
+  });
+}
+
+function hydrateEdgeEndpoints(
+  edges: GraphLinkDatum[],
+  vertexByKey: Map<string, GraphNodeDatum>,
+): void {
+  edges.forEach((edge) => {
+    edge.source = vertexByKey.get(endpointKey(edge.source)) ?? edge.source;
+    edge.target = vertexByKey.get(endpointKey(edge.target)) ?? edge.target;
+  });
+}
+
+function endpointKey(endpoint: string | GraphNodeDatum): string {
+  return typeof endpoint === "string" ? endpoint : endpoint.key;
 }
 
 export default ctx;

--- a/apps/frontend/src/workers/compute-graphv9.worker.ts
+++ b/apps/frontend/src/workers/compute-graphv9.worker.ts
@@ -85,7 +85,7 @@ ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
     1,
   );
   const groupCenterRadius =
-    Math.min(widthOf(layoutBounds), heightOf(layoutBounds)) * 0.43;
+    Math.min(widthOf(layoutBounds), heightOf(layoutBounds)) * 0.3;
 
   const simulation = forceSimulation<GraphNodeDatum>(simulatedVertices)
     .force(
@@ -98,7 +98,7 @@ ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
       "link",
       forceLink<GraphNodeDatum, GraphLinkDatum>(simulatedEdges)
         .distance((edge) => {
-          return edge.isPartOfTransitiveQuorumSet ? 112 : 170;
+          return edge.isPartOfTransitiveQuorumSet ? 96 : 118;
         })
         .strength((edge: SimulationLinkDatum<GraphNodeDatum>) => {
           const viewEdge = edge as GraphLinkDatum;
@@ -115,8 +115,8 @@ ctx.addEventListener("message", (event: MessageEvent<GraphWorkerPayload>) => {
     .force(
       "collision",
       forceCollide<GraphNodeDatum>()
-        .radius((vertex) => (vertex.isPartOfTransitiveQuorumSet ? 34 : 22))
-        .strength(0.72)
+        .radius(getCollisionRadius)
+        .strength(0.9)
         .iterations(2),
     )
     .force(
@@ -172,6 +172,14 @@ function groupCenter(
     x: center.x + Math.cos(angle) * radius,
     y: center.y + Math.sin(angle) * radius,
   };
+}
+
+function getCollisionRadius(vertex: GraphNodeDatum): number {
+  if (vertex.isPartOfTransitiveQuorumSet) {
+    return Math.max(40, vertex.label.length * 2.3);
+  }
+
+  return Math.max(28, Math.min(36, vertex.label.length * 2));
 }
 
 function getLayoutBounds(width: number, height: number): LayoutBounds {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
 
   apps/frontend:
     dependencies:
+      3d-force-graph:
+        specifier: 1.80.0
+        version: 1.80.0
       '@sentry/vue':
         specifier: ^8.34.0
         version: 8.55.0(vue@2.7.16)
@@ -358,6 +361,12 @@ importers:
       shared:
         specifier: workspace:*
         version: link:../../packages/shared
+      three:
+        specifier: 0.185.1
+        version: 0.185.1
+      three-spritetext:
+        specifier: 1.10.0
+        version: 1.10.0(three@0.185.1)
       vue:
         specifier: ^2.7.16
         version: 2.7.16
@@ -407,6 +416,9 @@ importers:
       '@types/node':
         specifier: ^26.0.1
         version: 26.0.1
+      '@types/three':
+        specifier: 0.185.0
+        version: 0.185.0
       '@vitejs/plugin-vue2':
         specifier: ^2.3.4
         version: 2.3.4(vite@6.3.5(@types/node@26.0.1)(sass@1.101.0))(vue@2.7.16)
@@ -877,6 +889,10 @@ importers:
         version: 0.67.4(@swc/core@1.15.43)(@swc/wasm@1.15.43)
 
 packages:
+
+  3d-force-graph@1.80.0:
+    resolution: {integrity: sha512-tzI353gW1nXPpnC7VTa3JjMg+3cp77qOLUFO0vucPTfF+q5R6sQsNsIqVTbRIb7RSypn14nBa4yfkOe9ThxASw==}
+    engines: {node: '>=12'}
 
   '@aws-sdk/checksums@3.1000.10':
     resolution: {integrity: sha512-OUNjNcyA8Ai2OdlRUxW5jHUf6XJmqqZk3UddL+mDiUCtXrVqdmIHHkdDFWBlBRjhore/3ZBMgRXgcS0ggtvD0Q==}
@@ -1555,6 +1571,9 @@ packages:
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -2365,6 +2384,12 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
+  '@tweenjs/tween.js@25.0.0':
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -2518,6 +2543,9 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
 
@@ -2527,6 +2555,9 @@ packages:
   '@types/swagger-ui-express@4.1.8':
     resolution: {integrity: sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==}
 
+  '@types/three@0.185.0':
+    resolution: {integrity: sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==}
+
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
 
@@ -2535,6 +2566,9 @@ packages:
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@types/workerpool@6.4.7':
     resolution: {integrity: sha512-DI2U4obcMzFViyNjLw0xXspim++qkAJ4BWRdYPVMMFtOpTvMr6PAk3UTZEoSqnZnvgUkJ3ck97Ybk+iIfuJHMg==}
@@ -2769,6 +2803,10 @@ packages:
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
+
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3251,6 +3289,13 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
@@ -3267,13 +3312,24 @@ packages:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
 
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
+    engines: {node: '>=12'}
+
   d3-force@3.0.0:
     resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
     engines: {node: '>=12'}
 
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
+
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
 
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
@@ -3287,12 +3343,28 @@ packages:
     resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
     engines: {node: '>=12'}
 
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
   d3-selection@3.0.0:
     resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
     engines: {node: '>=12'}
 
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
     engines: {node: '>=12'}
 
   d3-timer@3.0.1:
@@ -3307,6 +3379,10 @@ packages:
 
   d3-zoom@3.0.0:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  data-bind-mapper@1.0.3:
+    resolution: {integrity: sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==}
     engines: {node: '>=12'}
 
   date-fns@3.6.0:
@@ -3666,6 +3742,9 @@ packages:
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3695,6 +3774,10 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
 
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
@@ -3893,6 +3976,10 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   inversify@6.0.2:
     resolution: {integrity: sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==}
@@ -4168,6 +4255,10 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -4213,6 +4304,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -4273,6 +4367,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -4376,6 +4473,21 @@ packages:
   neverthrow@8.2.0:
     resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
     engines: {node: '>=18'}
+
+  ngraph.events@1.4.0:
+    resolution: {integrity: sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==}
+
+  ngraph.forcelayout@3.3.1:
+    resolution: {integrity: sha512-MKBuEh1wujyQHFTW57y5vd/uuEOK0XfXYxm3lC7kktjJLRdt/KEKEknyOlc6tjXflqBKEuYBBcu7Ax5VY+S6aw==}
+
+  ngraph.graph@20.1.2:
+    resolution: {integrity: sha512-W/G3GBR3Y5UxMLHTUCPP9v+pbtpzwuAEIqP5oZV+9IwgxAIEZwh+Foc60iPc1idlnK7Zxu0p3puxAyNmDvBd0Q==}
+
+  ngraph.merge@1.0.0:
+    resolution: {integrity: sha512-5J8YjGITUJeapsomtTALYsw7rFveYkM+lBj3QiYZ79EymQcuri65Nw3knQtFxQBU1r5iOaVRXrSwMENUPK62Vg==}
+
+  ngraph.random@1.2.0:
+    resolution: {integrity: sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -4598,6 +4710,10 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  polished@4.3.1:
+    resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
+    engines: {node: '>=10'}
+
   popper.js@1.16.1:
     resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
     deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
@@ -4630,6 +4746,9 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  preact@10.29.3:
+    resolution: {integrity: sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -5033,8 +5152,32 @@ packages:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
 
+  three-forcegraph@1.43.4:
+    resolution: {integrity: sha512-FtmiZP/T16ZQaHza3JDaDn0YTXFtg9e7pGnTeU8nzu0NNkx7MpWbF/GvmpbQsWHx3rukHtkRv1fTorLPB3FDEA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      three: '>=0.118.3'
+
+  three-render-objects@1.42.0:
+    resolution: {integrity: sha512-KYfkPrYGEbIK8ChFocWqOF1aAN80FBUBWVYB8mB2oBpVuVN+52FvvngVYB5ieFANQu7Rt21rPYZ/xKaAgVWWRQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      three: '>=0.179'
+
+  three-spritetext@1.10.0:
+    resolution: {integrity: sha512-t08iP1FCU1lQh8T5MmCpdijKgas8GDHJE0LqMGBuVu3xqMMpFnEZhTlih7FlxLPQizHIGoumUSpfOlY1GO/Tgg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      three: '>=0.86.0'
+
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
+
   tiny-emitter@2.1.0:
     resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
@@ -5581,6 +5724,14 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  3d-force-graph@1.80.0:
+    dependencies:
+      accessor-fn: 1.5.3
+      kapsule: 1.16.3
+      three: 0.185.1
+      three-forcegraph: 1.43.4(three@0.185.1)
+      three-render-objects: 1.42.0(three@0.185.1)
 
   '@aws-sdk/checksums@3.1000.10':
     dependencies:
@@ -6509,6 +6660,8 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
+  '@dimforge/rapier3d-compat@0.12.0': {}
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -7267,6 +7420,10 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@tweenjs/tween.js@23.1.3': {}
+
+  '@tweenjs/tween.js@25.0.0': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -7445,6 +7602,8 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
+  '@types/stats.js@0.17.4': {}
+
   '@types/superagent@8.1.9':
     dependencies:
       '@types/cookiejar': 2.1.5
@@ -7462,11 +7621,22 @@ snapshots:
       '@types/express': 4.17.23
       '@types/serve-static': 1.15.8
 
+  '@types/three@0.185.0':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/triple-beam@1.3.5': {}
 
   '@types/uuid@8.3.4': {}
 
   '@types/validator@13.15.10': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@types/workerpool@6.4.7':
     dependencies:
@@ -7717,6 +7887,8 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  accessor-fn@1.5.3: {}
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -8219,6 +8391,12 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-binarytree@1.0.2: {}
+
   d3-color@3.1.0: {}
 
   d3-dispatch@3.0.1: {}
@@ -8230,15 +8408,27 @@ snapshots:
 
   d3-ease@3.0.1: {}
 
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
   d3-force@3.0.0:
     dependencies:
       d3-dispatch: 3.0.1
       d3-quadtree: 3.0.1
       d3-timer: 3.0.1
 
+  d3-format@3.1.2: {}
+
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
+
+  d3-octree@1.1.0: {}
 
   d3-path@3.1.0: {}
 
@@ -8246,11 +8436,32 @@ snapshots:
 
   d3-quadtree@3.0.1: {}
 
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
   d3-selection@3.0.0: {}
 
   d3-shape@3.2.0:
     dependencies:
       d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
 
@@ -8270,6 +8481,10 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  data-bind-mapper@1.0.3:
+    dependencies:
+      accessor-fn: 1.5.3
 
   date-fns@3.6.0: {}
 
@@ -8629,6 +8844,8 @@ snapshots:
 
   fecha@4.2.3: {}
 
+  fflate@0.8.3: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -8669,6 +8886,12 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.3.3: {}
+
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.29.3
 
   fn.name@1.1.0: {}
 
@@ -8861,6 +9084,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  internmap@2.0.3: {}
 
   inversify@6.0.2: {}
 
@@ -9302,6 +9527,10 @@ snapshots:
       '@types/diff-match-patch': 1.0.36
       diff-match-patch: 1.0.5
 
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.18.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -9344,6 +9573,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -9401,6 +9632,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meshoptimizer@1.1.1: {}
 
   methods@1.1.2: {}
 
@@ -9474,6 +9707,22 @@ snapshots:
   neverthrow@8.2.0:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.44.1
+
+  ngraph.events@1.4.0: {}
+
+  ngraph.forcelayout@3.3.1:
+    dependencies:
+      ngraph.events: 1.4.0
+      ngraph.merge: 1.0.0
+      ngraph.random: 1.2.0
+
+  ngraph.graph@20.1.2:
+    dependencies:
+      ngraph.events: 1.4.0
+
+  ngraph.merge@1.0.0: {}
+
+  ngraph.random@1.2.0: {}
 
   node-addon-api@7.1.1:
     optional: true
@@ -9676,6 +9925,10 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  polished@4.3.1:
+    dependencies:
+      '@babel/runtime': 7.27.6
+
   popper.js@1.16.1: {}
 
   portal-vue@2.1.7(vue@2.7.16):
@@ -9702,6 +9955,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  preact@10.29.3: {}
 
   prelude-ls@1.2.1: {}
 
@@ -10126,7 +10381,38 @@ snapshots:
     dependencies:
       real-require: 1.0.0
 
+  three-forcegraph@1.43.4(three@0.185.1):
+    dependencies:
+      accessor-fn: 1.5.3
+      d3-array: 3.2.4
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      data-bind-mapper: 1.0.3
+      kapsule: 1.16.3
+      ngraph.forcelayout: 3.3.1
+      ngraph.graph: 20.1.2
+      three: 0.185.1
+      tinycolor2: 1.6.0
+
+  three-render-objects@1.42.0(three@0.185.1):
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      accessor-fn: 1.5.3
+      float-tooltip: 1.7.5
+      kapsule: 1.16.3
+      polished: 4.3.1
+      three: 0.185.1
+
+  three-spritetext@1.10.0(three@0.185.1):
+    dependencies:
+      three: 0.185.1
+
+  three@0.185.1: {}
+
   tiny-emitter@2.1.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyglobby@0.2.14:
     dependencies:


### PR DESCRIPTION
## Summary

- Tighten the 2D network graph layout so inner clusters stay readable while connectable-only perimeter nodes stay outside the first-load view.
- Add a lazy-loaded 3D graph mode with seeded layout, orbit controls, and an outer shell for perimeter nodes.
- Add typed helpers for 3D data conversion, camera framing, and force tuning.

## Validation

- `pnpm --filter frontend run build`
- BrowserOS desktop screenshot checks for 2D and 3D graph modes
- BrowserOS mobile-width 3D canvas check and screenshot
- Verified the 3D canvas produces non-empty image data

## Notes

The 3D graph bundle is code-split and loads only after selecting the 3D mode.